### PR TITLE
don't enforce default layer to be first, etc.

### DIFF
--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -20,7 +20,7 @@ class Font(object):
     _guidelines = attr.ib(default=None, init=False, repr=False, type=list)
     _info = attr.ib(default=None, init=False, repr=False, type=Info)
     _kerning = attr.ib(default=None, init=False, repr=False, type=dict)
-    _layers = attr.ib(default=attr.Factory(LayerSet), init=False, repr=False, type=LayerSet)
+    _layers = attr.ib(default=None, init=False, repr=False, type=LayerSet)
     _lib = attr.ib(default=None, init=False, repr=False, type=dict)
 
     _data = attr.ib(init=False, repr=False, type=DataSet)
@@ -30,11 +30,7 @@ class Font(object):
         if self._path is not None:
             reader = UFOReader(self._path)
             # load the layers
-            # XXX initialize LayerSet with a 'glyphSets' OrderedDict and
-            # an optional 'defaultLayerName'?
-            for name, glyphSet in reader.getGlyphSets().items():
-                self._layers.newLayer(name, glyphSet=glyphSet)
-            self._layers.defaultLayerName = reader.getDefaultLayerName()
+            self._layers = LayerSet.load(reader)
             # load data directory list
             data = reader.getDataDirectoryListing()
             self._data = DataSet(path=self._path, fileNames=data)
@@ -42,32 +38,30 @@ class Font(object):
             images = reader.getImageDirectoryListing()
             self._images = ImageSet(path=self._path, fileNames=images)
         else:
+            self._layers = LayerSet()
             self._data = DataSet()
             self._images = ImageSet()
 
-        if not self._layers:
-            self._layers.newLayer(DEFAULT_LAYER_NAME)
-
     def __contains__(self, name):
-        return name in self._layers.defaultLayer
+        return name in self._layers._defaultLayer
 
     def __delitem__(self, name):
-        del self._layers.defaultLayer[name]
+        del self._layers._defaultLayer[name]
 
     def __getitem__(self, name):
-        return self._layers.defaultLayer[name]
+        return self._layers._defaultLayer[name]
 
     def __iter__(self):
-        return iter(self._layers.defaultLayer)
+        return iter(self._layers._defaultLayer)
 
     def __len__(self):
-        return len(self._layers.defaultLayer)
+        return len(self._layers._defaultLayer)
 
     def get(self, name, default=None):
-        return self._layers.defaultLayer.get(name, default)
+        return self._layers._defaultLayer.get(name, default)
 
     def keys(self):
-        return self._layers.defaultLayer.keys()
+        return self._layers._defaultLayer.keys()
 
     @property
     def data(self):
@@ -157,16 +151,16 @@ class Font(object):
         return self._path
 
     def addGlyph(self, glyph):
-        self._layers.defaultLayer.addGlyph(glyph)
+        self._layers._defaultLayer.addGlyph(glyph)
 
     def newGlyph(self, name):
-        return self._layers.defaultLayer.newGlyph(name)
+        return self._layers._defaultLayer.newGlyph(name)
 
     def newLayer(self, name):
         return self._layers.newLayer(name)
 
     def renameGlyph(self, name, newName, overwrite=False):
-        self._layers.defaultLayer.renameGlyph(name, newName, overwrite)
+        self._layers._defaultLayer.renameGlyph(name, newName, overwrite)
 
     def renameLayer(self, name, newName, overwrite=False):
         self._layers.renameLayer(name, newName, overwrite)

--- a/src/ufoLib2/objects/font.py
+++ b/src/ufoLib2/objects/font.py
@@ -30,9 +30,11 @@ class Font(object):
         if self._path is not None:
             reader = UFOReader(self._path)
             # load the layers
-            for name, dirName in reader.getLayerContents():
-                glyphSet = reader.getGlyphSet(dirName)
+            # XXX initialize LayerSet with a 'glyphSets' OrderedDict and
+            # an optional 'defaultLayerName'?
+            for name, glyphSet in reader.getGlyphSets().items():
                 self._layers.newLayer(name, glyphSet=glyphSet)
+            self._layers.defaultLayerName = reader.getDefaultLayerName()
             # load data directory list
             data = reader.getDataDirectoryListing()
             self._data = DataSet(path=self._path, fileNames=data)

--- a/src/ufoLib2/objects/layer.py
+++ b/src/ufoLib2/objects/layer.py
@@ -2,11 +2,12 @@ import attr
 from typing import Optional
 from ufoLib2.objects.glyph import Glyph, GlyphClasses
 from ufoLib2.reader import GlyphSet
+from ufoLib2.constants import DEFAULT_LAYER_NAME
 
 
 @attr.s(slots=True)
 class Layer(object):
-    _name = attr.ib(type=str)
+    _name = attr.ib(default=DEFAULT_LAYER_NAME, type=str)
     _glyphSet = attr.ib(default=None, repr=False, type=GlyphSet)
     _glyphs = attr.ib(default=attr.Factory(dict), init=False, repr=False, type=dict)
     _keys = attr.ib(init=False, repr=False, type=set)

--- a/src/ufoLib2/objects/layerSet.py
+++ b/src/ufoLib2/objects/layerSet.py
@@ -1,18 +1,65 @@
 import attr
 from collections import OrderedDict
 from ufoLib2.objects.layer import Layer
-from ufoLib2.constants import DEFAULT_GLYPHS_DIRNAME
+from ufoLib2.constants import DEFAULT_LAYER_NAME
+from fontTools.misc.py23 import basestring
+
+
+def _layersConverter(value):
+    # takes an iterable of Layer objects and returns an OrderedDict keyed
+    # by layer name
+    layers = OrderedDict()
+    for layer in value:
+        if not isinstance(layer, Layer):
+            raise TypeError(
+                "expected 'Layer', found '%s'" % type(layer).__name__)
+        if layer.name in layers:
+            raise KeyError("duplicate layer name: '%s'" % layer.name)
+        layers[layer.name] = layer
+    return layers
 
 
 @attr.s(slots=True, repr=False)
 class LayerSet(object):
     _layers = attr.ib(
-        default=attr.Factory(OrderedDict),
-        init=False,
+        default=(),
+        converter=_layersConverter,
         type=OrderedDict)
-    _defaultLayerName = attr.ib(default=None, init=False, type=str)
+    _defaultLayer = attr.ib(default=None, type=Layer)
     _scheduledForDeletion = attr.ib(
         default=attr.Factory(set), init=False, type=set)
+
+    def __attrs_post_init__(self):
+        if not self._layers:
+            # LayerSet is never empty; always contains at least the default
+            if self._defaultLayer is not None:
+                raise TypeError(
+                    "'defaultLayer' argument is invalid with empty LayerSet")
+            self._defaultLayer = self.newLayer(DEFAULT_LAYER_NAME)
+        elif self._defaultLayer is not None:
+            # check that the specified default layer is in the layer set;
+            # 'defaultLayer' constructor argument is a string (the name),
+            # whereas the 'defaultLayer' property is a Layer object
+            default = self._defaultLayer
+            if isinstance(default, basestring):
+                if default not in self._layers:
+                    raise KeyError(default)
+                self._defaultLayer = self._layers[default]
+            else:
+                raise TypeError(
+                    "'defaultLayer': expected string, found '%s'"
+                    % type(default).__name__)
+        else:
+            if DEFAULT_LAYER_NAME not in self._layers:
+                raise ValueError("default layer not specified")
+            self._defaultLayer = self._layers[DEFAULT_LAYER_NAME]
+
+    @classmethod
+    def load(cls, reader):
+        return cls(
+            (Layer(name=name, glyphSet=glyphSet)
+             for name, glyphSet in reader.iterGlyphSets()),
+            defaultLayer=reader.getDefaultLayerName())
 
     def __contains__(self, name):
         return name in self._layers
@@ -43,29 +90,20 @@ class LayerSet(object):
                            repr(list(self)) if self._layers else "")
 
     @property
-    def defaultLayerName(self):
-        return self._defaultLayerName  # XXX can be None!
-
-    @defaultLayerName.setter
-    def defaultLayerName(self, name):
-        if name not in self._layers:
-            raise KeyError('layer name "%s" not in layer set' % name)
-        self._defaultLayerName = name
-
-    @property
     def defaultLayer(self):
-        if self.defaultLayerName is None:
-            return
-        return self._layers[self.defaultLayerName]
+        return self._defaultLayer
 
     @defaultLayer.setter
     def defaultLayer(self, layer):
-        for this in self:
+        if not isinstance(layer, Layer):
+            raise TypeError(
+                "expected 'Layer', found '%s'" % type(layer).__name__)
+        for this in self._layers.values():
             if this is layer:
                 break
         else:
             raise KeyError("layer %r is not in layer set" % layer)
-        self._defaultLayerName = layer.name
+        self._defaultLayer = layer
 
     @property
     def layerOrder(self):
@@ -121,8 +159,6 @@ class LayerSet(object):
         if newName in self._scheduledForDeletion:
             self._scheduledForDeletion.remove(newName)
         layer._name = newName
-        if name == self._defaultLayerName:
-            self._defaultLayerName = newName
 
     def save(self, writer, saveAs=False):
         # if in-place, remove deleted layers
@@ -132,7 +168,7 @@ class LayerSet(object):
         # write layers
         defaultLayer = self.defaultLayer
         for layer in self:
-            default = layer == defaultLayer
+            default = layer is defaultLayer
             glyphSet = writer.getGlyphSet(layer.name, default=default)
             layer.save(glyphSet, saveAs=saveAs)
             # do this need a separate call?

--- a/src/ufoLib2/objects/layerSet.py
+++ b/src/ufoLib2/objects/layerSet.py
@@ -4,16 +4,15 @@ from ufoLib2.objects.layer import Layer
 from ufoLib2.constants import DEFAULT_GLYPHS_DIRNAME
 
 
-@attr.s(slots=True)
+@attr.s(slots=True, repr=False)
 class LayerSet(object):
     _layers = attr.ib(
         default=attr.Factory(OrderedDict),
         init=False,
-        repr=False,
         type=OrderedDict)
-    _defaultLayerName = attr.ib(default=None, init=False, repr=False, type=str)
+    _defaultLayerName = attr.ib(default=None, init=False, type=str)
     _scheduledForDeletion = attr.ib(
-        default=attr.Factory(set), init=False, repr=False, type=set)
+        default=attr.Factory(set), init=False, type=set)
 
     def __contains__(self, name):
         return name in self._layers
@@ -39,6 +38,10 @@ class LayerSet(object):
     def keys(self):
         return self._layers.keys()
 
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__,
+                           repr(list(self)) if self._layers else "")
+
     @property
     def defaultLayerName(self):
         return self._defaultLayerName  # XXX can be None!
@@ -46,7 +49,7 @@ class LayerSet(object):
     @defaultLayerName.setter
     def defaultLayerName(self, name):
         if name not in self._layers:
-            raise KeyError('layer name "%s" not in layer set')
+            raise KeyError('layer name "%s" not in layer set' % name)
         self._defaultLayerName = name
 
     @property
@@ -118,6 +121,8 @@ class LayerSet(object):
         if newName in self._scheduledForDeletion:
             self._scheduledForDeletion.remove(newName)
         layer._name = newName
+        if name == self._defaultLayerName:
+            self._defaultLayerName = newName
 
     def save(self, writer, saveAs=False):
         # if in-place, remove deleted layers

--- a/src/ufoLib2/reader.py
+++ b/src/ufoLib2/reader.py
@@ -106,11 +106,10 @@ class UFOReader(object):
         path = os.path.join(self._path, dirName)
         return GlyphSet(path)
 
-    def getGlyphSets(self):
-        """Return an OrderedDict of GlyphSet objects keyed by layer name."""
-        return OrderedDict((layerName,
-                            GlyphSet(os.path.join(self._path, dirName)))
-                           for layerName, dirName in self.getLayerContents())
+    def iterGlyphSets(self):
+        """Return an iterator over (layerName, GlyphSet) tuples."""
+        for layerName, dirName in self.getLayerContents():
+            yield layerName, GlyphSet(os.path.join(self._path, dirName))
 
     # bin
 

--- a/src/ufoLib2/reader.py
+++ b/src/ufoLib2/reader.py
@@ -3,7 +3,6 @@ import attr
 import os
 import errno
 from io import open
-from collections import OrderedDict
 from ufoLib2 import plistlib
 from ufoLib2.constants import (
     DATA_DIRNAME, DEFAULT_GLYPHS_DIRNAME, FEATURES_FILENAME, FONTINFO_FILENAME,

--- a/src/ufoLib2/reader.py
+++ b/src/ufoLib2/reader.py
@@ -8,7 +8,7 @@ from ufoLib2 import plistlib
 from ufoLib2.constants import (
     DATA_DIRNAME, DEFAULT_GLYPHS_DIRNAME, FEATURES_FILENAME, FONTINFO_FILENAME,
     GROUPS_FILENAME, IMAGES_DIRNAME, KERNING_FILENAME, LAYERCONTENTS_FILENAME,
-    LIB_FILENAME)
+    LIB_FILENAME, DEFAULT_LAYER_NAME)
 from ufoLib2.glyphSet import GlyphSet
 
 
@@ -81,12 +81,21 @@ class UFOReader(object):
         return self._layerContents
 
     def getDefaultLayerName(self):
+        defaultLayerName = None
+        publicDefaultDir = None
         for layerName, layerDirectory in self.getLayerContents():
             if layerDirectory == DEFAULT_GLYPHS_DIRNAME:
-                return layerName
-        else:
-            # we checked it already
-            assert 0, "default layer not found!"
+                defaultLayerName = layerName
+            if layerName == DEFAULT_LAYER_NAME:
+                publicDefaultDir = layerDirectory
+        if (publicDefaultDir is not None
+                and publicDefaultDir != DEFAULT_GLYPHS_DIRNAME):
+            raise ValueError(
+                "'public.default' assigned to non-default directory: '%s'"
+                % publicDefaultDir)
+        # we checked it already
+        assert defaultLayerName is not None, "default layer not found!"
+        return defaultLayerName
 
     def getLayerNames(self):
         # for backward-compat with ufoLib API


### PR DESCRIPTION
follow the spec and set the default to the layer whose directory is named "glyphs" (the name of the layer can be user-defined, else it must be "public.default" -- though we don't validate that here yet).

Also:
- ~~added a new `getGlyphSets` method to the reader that returns an ordered dict of GlyphSets keyed by name;~~
- added `UFOReader.iterGlyphSets` method that returns an iterator over (layerName, GlyphSet) tuples
- ~~added a `defaultLayerName` property to LayerSet~~
- added `LayerSet.load` class constructor that takes a UFOReader instance and loads the layer set 
- added some backward-compatibility methods from the old ufoLib UFOReader api.